### PR TITLE
issue must be instance of module

### DIFF
--- a/src/webpack-modification/compilation/inject.js
+++ b/src/webpack-modification/compilation/inject.js
@@ -88,7 +88,7 @@ function getModuleIdentifier(dependency) {
 }
 
 function link(topLevelModule, module, dependecy) {
-    module.issuer = topLevelModule.identifier();
+    module.issuer = topLevelModule;
     dependecy.module = module;
     module.addReason(topLevelModule, dependecy);
 }


### PR DESCRIPTION
WebPack is throwing error in Stats because issuer is a string

Ref.: https://github.com/webpack/webpack/blob/master/lib/Stats.js#L335

Same PR against Webpack v2: #5 